### PR TITLE
Ignore errors thrown by json-pointer

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,26 +77,33 @@ var new_client = function(api_key, config) {
 
     this.es.addEventListener('patch', function(e) {
       if (e && e.data) {
-        var patch = JSON.parse(e.data);
-        if (patch && patch.path && patch.data && patch.data.version) {
-          old = pointer.get(_self.features, patch.path);
-          if (old === null || old.version < patch.data.version) {
-            pointer.set(_self.features, patch.path, patch.data);
+        try {
+          var patch = JSON.parse(e.data);
+          if (patch && patch.path && patch.data && patch.data.version) {
+            old = pointer.get(_self.features, patch.path);
+            if (old === null || old.version < patch.data.version) {
+              pointer.set(_self.features, patch.path, patch.data);
+            }
           }
-        }
+        } catch(e) {}  // do not update a flag that does not exist
       }
     });
 
     this.es.addEventListener('delete', function(e) {
       if (e && e.data) {
-        var data = JSON.parse(e.data);
+        try {
+          var data = JSON.parse(e.data);
 
-        if (data && data.path && data.version) {
-          old = pointer.get(_self.features, data.path);
-          if (old === null || old.version < data.version) {
-            pointer.set(_self.features, data.path, {"deleted": true, "version": data.version});         
+          if (data && data.path && data.version) {
+            old = pointer.get(_self.features, data.path);
+            if (old === null || old.version < data.version) {
+              pointer.set(_self.features, data.path, {
+                "deleted": true,
+                "version": data.version
+              });
+            }
           }
-        }
+        } catch(e) {}  // do not delete a flag that does not exist
       }
     });
 


### PR DESCRIPTION
Ignore errors thrown by json-pointer, on invalid update and delete events.

Fixes https://github.com/launchdarkly/node-client/issues/25