### PR TITLE
Skip the check of an API key when configured to be offline.

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,16 +45,15 @@ var new_client = function(api_key, config) {
   );
   config.feature_store = config.feature_store || InMemoryFeatureStore();
 
-  api_key = api_key;
   queue = [];
 
-  if (!api_key) {
+  if (!api_key && !config.offline) {
     throw new Error("You must configure the client with an API key");
   }
 
-  requestor = Requestor(api_key, config);
-
   if (!config.use_ldd && !config.offline) {
+    requestor = Requestor(api_key, config);
+
     if (config.stream) {
       config.logger.info("[LaunchDarkly] Initializing stream processor to receive feature flag updates");
       update_processor = StreamingProcessor(api_key, config, requestor);

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,20 @@ match_target = ld.__get__('match_target');
 match_user = ld.__get__('match_user');
 sanitize_user = ld.__get__('sanitize_user');
 
+describe('init', function() {
+    it('should throw when called without an api key and options.offline falsy', function() {
+        assert.throws(function(){
+            return ld.init('', {});
+        }, /You must configure the client with an API key/);
+    });
+
+    it('should not throw when called without an api key and options.offline truthy', function() {
+        assert.doesNotThrow(function(){
+            return ld.init('', {offline: true});
+        })
+    });
+});
+
 describe('match_target', function() {
   it('should match users based on top-level attributes', function () {
     var u = {key: 'foo', firstName: 'alice'};


### PR DESCRIPTION
In offline mode no requests are made, so an API key is not strictly necessary. It's convenient to allow no key when the client is interacting with unit tests, or in development.

Since it's easy to work around this I've put a minimal changeset in this PR. If you think it would make a good addition, I'd be happy to add companion tests.