### PR TITLE
Fixed an error in feature_store, if a flag value is undefined

### DIFF
--- a/feature_store.js
+++ b/feature_store.js
@@ -28,7 +28,7 @@ function InMemoryFeatureStore() {
     for (var key in this.flags) {
       if (this.flags.hasOwnProperty(key)) {
         var flag = this.flags[key];
-        if (!flag.deleted) {
+        if (flag && !flag.deleted) {
           results[key] = clone(flag);          
         }
       }


### PR DESCRIPTION
After deleting a flag on production, I got this error:


```
TypeError: Cannot read property 'deleted' of undefined
    at Object.InMemoryFeatureStore.store.all (/var/app/current/node_modules/ldclient-node/feature_store.js:31:18)
    at EventEmitter.client.all_flags (/var/app/current/node_modules/ldclient-node/index.js:140:26)
    at DarklyLaboratory.js:13:16
    at new wrappedPromise (/var/app/current/node_modules/newrelic/lib/instrumentation/core/globals.js:133:18)
    at DarklyLaboratory.js:12:17
    at wrappedPromise.linkTransaction 
```

This is due to an `undefined` value in the flag list. This PR fixes it.