### PR TITLE
Emit listenable 'ready' event when in offline mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,9 @@ var new_client = function(sdk_key, config) {
       }
     });
   } else {
-    client.emit('ready');
+    process.nextTick(function() {
+      client.emit('ready');
+    });
   }
 
   client.initialized = function() {


### PR DESCRIPTION
Previously it was impossible for the 'ready' event to be seen by any listener when in offline mode, because the event was fired before any listener could be attached.