### PR TITLE
Sanitize user in all_flags call

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,6 +160,7 @@ var new_client = function(sdk_key, config) {
   }
 
   client.all_flags = function(user, fn) {
+    sanitize_user(user);
     var cb = fn || noop;
     var results = {};
 


### PR DESCRIPTION
This addresses #53 -- we were failing to sanitize non-string user keys in all_flags calls.