### PR TITLE
Log short errors for known errors

### DIFF
--- a/eventsource.js
+++ b/eventsource.js
@@ -40,7 +40,7 @@ function EventSource(url, eventSourceInitDict) {
     if (connectPending || readyState === EventSource.CLOSED) return;
     connectPending = true;
     readyState = EventSource.CONNECTING;
-    _emit('error', new Event('error'));
+    _emit('error', new Event('error', {message: 'Connection closed, reconnecting'}));
 
     // The url may have been changed by a temporary
     // redirect. If that's the case, revert it now.

--- a/index.js
+++ b/index.js
@@ -67,8 +67,10 @@ var new_client = function(sdk_key, config) {
         var error;
         if ((err.status && err.status === 401) || (err.code && err.code === 401)) {
           error = new Error("Authentication failed. Double check your SDK key.");
+        } else if (err.message) {
+          error = "Error: " + err.message;
         } else {
-          error = new Error("Unexpected error:", err.message ? err.message : err);
+          error = new Error("Unexpected error:", err);
         }
         
         config.logger.error("[LaunchDarkly]", error);


### PR DESCRIPTION
For errors with known messages, just log out the message. Don't give an Error to winston so it won't print a stack trace. If we have a message, it should be clear where the error came from.

```js
error: [LaunchDarkly] Error: Unexpected error: "message"
    at /.../node_modules/ldclient-node/index.js:73:19
    at EventSource.es.onerror (/.../node_modules/ldclient-node/streaming.js:19:7)
    at emitOne (events.js:96:13)
    at EventSource.emit (events.js:188:7)
    at _emit (/.../node_modules/ldclient-node/eventsource.js:188:17)
    at EventSource.foo (/.../node_modules/ldclient-node/eventsource.js:40:5)
    at Object.StreamProcessor.processor.start (/.../node_modules/ldclient-node/streaming.js:86:8)
    at Object.new_client [as init] (/.../node_modules/ldclient-node/index.js:64:22)
    at Object.<anonymous> (/.../fake-node-client/index.js:3:31)
    at Module._compile (module.js:570:32)
```

will now look like this:
```js
error: [LaunchDarkly] Error: "message"
```