### PR TITLE
Fix type defs (implicit any)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -308,7 +308,7 @@ declare module "ldclient-node" {
      *  Truthy if the cache is already initialized.
      *
      */
-    initialized: (callback?: (err) => void) => boolean;
+    initialized: (callback?: (err: any) => void) => boolean;
 
     /**
      * Close the feature store.


### PR DESCRIPTION
Fixes

```
> tsc

node_modules/ldclient-node/index.d.ts(311,31): error TS7006: Parameter 'err' implicitly has an 'any' type.
```