### PR TITLE
Support `undefined` user attributes

### DIFF
--- a/evaluate_flag.js
+++ b/evaluate_flag.js
@@ -157,7 +157,7 @@ function clause_match_user(c, user) {
 
   uValue = user_value(user, c.attribute);
 
-  if (uValue === null) {
+  if (uValue === null || uValue === undefined) {
     return false;
   }
 


### PR DESCRIPTION
Fixes "Cannot read property 'constructor' of undefined" TypeError when user attributes are `undefined`.

See also #51