### PR TITLE
prepare 5.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the LaunchDarkly Node.js SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [5.0.1] - 2018-05-31
+
+### Fixed:
+- Fixed a bug that caused summary events to combine two different counters: a) flag evaluations that produced the flag's first variation, and b) counts for flag evaluations that fell through to the default value.
+
+### Removed:
+- Removed debug-level logging that was listing every analytics event.
+
 ## [5.0.0] - 2018-05-10
 
 ### Changed:

--- a/event_processor.js
+++ b/event_processor.js
@@ -97,7 +97,6 @@ function EventProcessor(sdkKey, config, errorReporter) {
     if (shutdown) {
       return;
     }
-    config.logger.debug("Sending event", JSON.stringify(event));
 
     // Always record the event in the summarizer.
     summarizer.summarizeEvent(event);

--- a/event_summarizer.js
+++ b/event_summarizer.js
@@ -8,7 +8,11 @@ function EventSummarizer(config) {
   
   es.summarizeEvent = function(event) {
     if (event.kind === 'feature') {
-      var counterKey = event.key + ':' + (event.variation || '') + (event.version || '');
+      var counterKey = event.key +
+        ':' +
+        ((event.variation !== null && event.variation !== undefined) ? event.variation : '') +
+        ':' +
+        ((event.version !== null && event.version !== undefined) ? event.version : '');
       var counterVal = counters[counterKey];
       if (counterVal) {
         counterVal.count = counterVal.count + 1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-node",
-  "version": "4.0.5",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-node",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "LaunchDarkly SDK for Node.js",
   "main": "index.js",
   "scripts": {

--- a/test/event_summarizer-test.js
+++ b/test/event_summarizer-test.js
@@ -71,4 +71,30 @@ describe('EventSummarizer', function() {
     };
     expect(data.features).toEqual(expectedFeatures);
   });
+
+  it('distinguishes between zero and null/undefined in feature variation', function() {
+    var es = EventSummarizer();
+    var event1 = { kind: 'feature', creationDate: 1000, key: 'key1', version: 11, user: user,
+      variation: 0, value: 100, default: 111 };
+    var event2 = { kind: 'feature', creationDate: 1000, key: 'key1', version: 11, user: user,
+      variation: null, value: 111, default: 111 };
+    var event3 = { kind: 'feature', creationDate: 1000, key: 'key1', version: 11, user: user,
+      /* variation undefined */ value: 111, default: 111 };
+    es.summarizeEvent(event1);
+    es.summarizeEvent(event2);
+    es.summarizeEvent(event3);
+    var data = es.getSummary();
+
+    data.features.key1.counters.sort(function(a, b) { return a.value - b.value; });
+    var expectedFeatures = {
+      key1: {
+        default: 111,
+        counters: [
+          { variation: 0, value: 100, version: 11, count: 1 },
+          { value: 111, version: 11, count: 2 }
+        ]
+      }
+    };
+    expect(data.features).toEqual(expectedFeatures);
+  });
 });


### PR DESCRIPTION
## [5.0.1] - 2018-05-31

### Fixed:
- Fixed a bug that caused summary events to combine two different counters: a) flag evaluations that produced the flag's first variation, and b) counts for flag evaluations that fell through to the default value.

### Removed:
- Removed debug-level logging that was listing every analytics event.
