### PR TITLE
prepare 5.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the LaunchDarkly Node.js SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [5.0.1] - 2018-05-31
+
+### Fixed:
+- Fixed a bug that caused summary events to combine two different counters: a) flag evaluations that produced the flag's first variation, and b) counts for flag evaluations that fell through to the default value.
+
+### Removed:
+- Removed debug-level logging that was listing every analytics event.
+
 ## [5.0.0] - 2018-05-10
 
 ### Changed:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-node",
-  "version": "4.0.5",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-node",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "LaunchDarkly SDK for Node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## [5.0.2] - 2018-06-15

### Fixed:
- Removed an indirect dependency on an old version of the `querystringify` module, which had a [security flaw](https://github.com/unshiftio/querystringify/pull/19). ([#97](https://github.com/launchdarkly/node-client/issues/97))
- Updated TypeScript definitions for client options. (Thanks, [stepanataccolade](https://github.com/launchdarkly/node-client/pull/95#pullrequestreview-126088214)!)