### PR TITLE
prepare 5.1.1 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-node",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -22,6 +22,25 @@
         "chalk": "2.3.2",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
+      }
+    },
+    "@types/events": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
+    },
+    "@types/node": {
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.5.2.tgz",
+      "integrity": "sha512-m9zXmifkZsMHZBOyxZWilMwmTlpC8x5Ty360JKTiXvlXZfBWYpsg9ZZvP/Ye+iZUh+Q+MxDLjItVTWIsfwz+8Q=="
+    },
+    "@types/redis": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.6.tgz",
+      "integrity": "sha512-kaSI4XQwCfJtPiuyCXvLxCaw2N0fMZesdob3Jh01W20vNFct+3lfvJ/4yCJxbSopXOBOzpg+pGxkW6uWZrPZHA==",
+      "requires": {
+        "@types/events": "1.2.0",
+        "@types/node": "10.5.2"
       }
     },
     "abab": {
@@ -5708,7 +5727,7 @@
     },
     "tunnel": {
       "version": "https://github.com/launchdarkly/node-tunnel/tarball/d860e57650cce1ea655d00854c81babe6b47e02c",
-      "integrity": "sha512-prl+yIntUTIhkHoz2YtT7xtcAoMEgfsm+RL2bUGFI6e229NTICfo+jFKj1UFCDqc1wm/SQK7TM2U06sgeoO9jQ=="
+      "integrity": "sha1-DxkgfzcgRtPUaCGDy+INSgR8zdk="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/launchdarkly/node-client",
   "dependencies": {
+    "@types/redis": "2.8.6",
     "async": "2.6.0",
     "crypto": "0.0.3",
     "hoek": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "node-cache": "^3.2.1",
     "node-sha1": "0.0.1",
     "redis": "^2.6.0-2",
-    "request": "2.85.0",
+    "request": "2.87.0",
     "request-etag": "^2.0.3",
     "semver": "5.5.0",
     "tunnel": "https://github.com/launchdarkly/node-tunnel/tarball/d860e57650cce1ea655d00854c81babe6b47e02c",


### PR DESCRIPTION
## [5.1.1] - 2018-07-19

### Fixed:
- Now outputs a more descriptive log message if `allFlags` is called with a null user object. (Thanks, [jbatchelor-atlassian](https://github.com/launchdarkly/node-client/pull/103)!)
- Added TypeScript definitions for some previously undefined types.
- Updated `request` package dependency to `2.87.0`, to avoid a [security vulnerability](https://snyk.io/vuln/npm:cryptiles:20180710) in a package used by `request`.