### PR TITLE
Remove global variable from event_summarizer

### DIFF
--- a/event_summarizer.js
+++ b/event_summarizer.js
@@ -47,7 +47,7 @@ function EventSummarizer(config) {
         };
         flagsOut[c.key] = flag;
       }
-      counterOut = {
+      var counterOut = {
         value: c.value,
         count: c.count
       };


### PR DESCRIPTION
This can cause errors in Mocha tests. 

```global leak detected: counterOut```

![](https://media.giphy.com/media/l3q2MDnkLri1t7i5a/giphy.gif)