### PR TITLE
ensure the default config does not share the featureStore

### DIFF
--- a/configuration.js
+++ b/configuration.js
@@ -4,23 +4,25 @@ var messages = require('./messages');
 var package_json = require('./package.json');
 
 module.exports = (function() {
-  var defaults = {
-    baseUri: 'https://app.launchdarkly.com',
-    streamUri: 'https://stream.launchdarkly.com',
-    eventsUri: 'https://events.launchdarkly.com',
-    stream: true,
-    sendEvents: true,
-    timeout: 5,
-    capacity: 1000,
-    flushInterval: 5,
-    pollInterval: 30,
-    offline: false,
-    useLdd: false,
-    allAttributesPrivate: false,
-    privateAttributeNames: [],
-    userKeysCapacity: 1000,
-    userKeysFlushInterval: 300,
-    featureStore: InMemoryFeatureStore()
+  var defaults = function() {
+    return {
+      baseUri: 'https://app.launchdarkly.com',
+      streamUri: 'https://stream.launchdarkly.com',
+      eventsUri: 'https://events.launchdarkly.com',
+      stream: true,
+      sendEvents: true,
+      timeout: 5,
+      capacity: 1000,
+      flushInterval: 5,
+      pollInterval: 30,
+      offline: false,
+      useLdd: false,
+      allAttributesPrivate: false,
+      privateAttributeNames: [],
+      userKeysCapacity: 1000,
+      userKeysFlushInterval: 300,
+      featureStore: InMemoryFeatureStore()
+    };
   };
 
   var deprecatedOptions = {
@@ -87,7 +89,7 @@ module.exports = (function() {
     
     checkDeprecatedOptions(config);
 
-    config = applyDefaults(config, defaults);
+    config = applyDefaults(config, defaults());
 
     config.baseUri = canonicalizeUri(config.baseUri);
     config.streamUri = canonicalizeUri(config.streamUri);

--- a/test/configuration-test.js
+++ b/test/configuration-test.js
@@ -69,4 +69,10 @@ describe('configuration', function() {
     var config = configuration.validate({ pollInterval: 31 });
     expect(config.pollInterval).toEqual(31);
   });
+
+  it('should not share the default featureStore across different config instances', function() {
+    var config1 = configuration.validate({});
+    var config2 = configuration.validate({});
+    expect(config1.featureStore).not.toEqual(config2.featureStore);
+  });
 });


### PR DESCRIPTION
Hello,

We tried upgrading to v5.6.1 (from 3.4.0) of the client today and ran into an issue with retrieving all of our features. Our app retrieves features from 4 different LD projects and we were noticing that only the features from a single project were coming back. Debugging into this, the root cause is that all 4 of our LD client instances are using the same `featureStore` object. If we adjust the configuration object to create a new `InMemoryFeatureStore` each time defaults are applied, as I've done in this PR, the issue goes away.

If these changes are desirable, another possible solution would be to export `InMemoryFeatureStore` just like `RedisFeatureStore` so consumers that need to use multiple clients can do something like this:

```js
let ldClient = LaunchDarkly.init(sdkKey, {
    featureStore: LaunchDarkly.InMemoryFeatureStore()
});
```

Happy to adjust this PR as needed. Thanks!

Note: sounds like this may be related to #127