### PR TITLE
Bump semver from 7.3.0 to 7.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "launchdarkly-eventsource": "1.4.4",
     "lru-cache": "^6.0.0",
     "node-cache": "^5.1.0",
-    "semver": "^7.3.0",
+    "semver": "^7.5.4",
     "tunnel": "0.0.6",
     "uuid": "^8.3.2"
   },


### PR DESCRIPTION
**Requirements**

- [x] ~I have added test coverage for new or changed functionality~ (Just a package bump, no changed functionality) 
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

[CVE-2022-25883](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw)

**Describe the solution you've provided**

The security warning [CVE-2022-25883](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw) mentions that there was a ReDos through semver's Range function, which is not used in this codebase. However, having the old version causes security warnings for tools that use the `launchdarkly-node-server-sdk` npm package.

**Describe alternatives you've considered**

An alternative is waiting for the LaunchDarkly SDK team to update this themselves, or to open an issue to track this, but since it's a minor patch bump, I thought this was the most convenient way.

**Additional context**

n/a
